### PR TITLE
docs: Fix the location of the design document

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ Feature requests and pull requests are very much appreciated and welcome!
 Anyhow, please talk to me a bit about your ideas before you start hacking!
 It's always nice to know what you're working on and I might have a few suggestions or tips :)
 
-There's also the [Design.md](https://github.com/Nukesor/bois/blob/main/docs/Design.md), which is supposed to give you a brief overview and introduction to the project.
+There's also the [Design.md](https://github.com/Nukesor/bois/blob/main/dev_docs/Architecture/Design.md), which is supposed to give you a brief overview and introduction to the project.
 
 Copyright &copy; 2024 Arne Beer ([@Nukesor](https://github.com/Nukesor))


### PR DESCRIPTION
It seems this was not updated when the docs got moved.

## Checklist

Please make sure the PR adheres to this project's standards:

- [ ] I included a new entry to the `CHANGELOG.md`. <-- is this newsworthy enough to require an entry there? :thinking: 
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway. <-- it shouldn't complain about this
- [ ] (If applicable) I went through the books to see if anything needed changing or adding and made the updates as needed. <-- I fixed that in one location and didn't check others!
